### PR TITLE
Use correct type for forbid-prop-types

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,7 @@ module.exports = {
          * React plugin
          */
         "react/display-name": 0,
-        "react/forbid-prop-types": [2, {"forbid": "any"}],
+        "react/forbid-prop-types": [2, {"forbid": ["any"]}],
         "react/jsx-boolean-value": 2,
         "react/jsx-closing-bracket-location": 0,
         "react/jsx-curly-spacing": [2, "never"],


### PR DESCRIPTION
With eslint (2.2.0), eslint-plugin-react (4.2.1) and default rules, I get this error.

> Configuration for rule "react/forbid-prop-types" is invalid:
> Value "any" is the wrong type.

That's because the schema for react/forbid-prop-types expects and array:
https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/forbid-prop-types.js#L124

while you are giving just the default value:

https://github.com/patrio/eslint-config-react/blob/master/index.js#L240
