### PR TITLE
Removes eslint 2 deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@ module.exports = {
     "parser": "babel-eslint",
 
     "parserOptions": {
-      "ecmaVersion": 6,
-      "ecmaFeatures": {
-        "jsx": true
-      },
-      "sourceType": "module"
+        "ecmaVersion": 6,
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "sourceType": "module"
     },
 
     "plugins": [

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ module.exports = {
     "parserOptions": {
       "ecmaVersion": 6,
       "ecmaFeatures": {
-          "jsx": true
+        "jsx": true
       },
       "sourceType": "module"
     },

--- a/index.js
+++ b/index.js
@@ -1,23 +1,12 @@
 module.exports = {
     "parser": "babel-eslint",
 
-    "ecmaFeatures": {
-        "arrowFunctions": true,
-        "blockBindings": true,
-        "classes": true,
-        "defaultParams": true,
-        "destructuring": true,
-        "forOf": true,
-        "generators": false,
-        "modules": true,
-        "objectLiteralComputedProperties": true,
-        "objectLiteralDuplicateProperties": false,
-        "objectLiteralShorthandMethods": true,
-        "objectLiteralShorthandProperties": true,
-        "spread": true,
-        "superInFunctions": true,
-        "templateStrings": true,
-        "jsx": true
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "ecmaFeatures": {
+          "jsx": true
+      },
+      "sourceType": "module"
     },
 
     "plugins": [


### PR DESCRIPTION
Updates config for eslint 2 according to [this guide](https://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options).

Deprecation warning removed:
` DeprecationWarning: [eslint] The 'ecmaFeatures' config file property is deprecated, and has no effect.`

